### PR TITLE
Update versions of build-gradle-plugin and dependencies 

### DIFF
--- a/aroma-core/build.gradle
+++ b/aroma-core/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     def aromaCoreTestDependencies = rootProject.ext.aromaCoreTestDependencies
 
     implementation aromaCoreDependencies.supportAnnotations
-    implementation aromaCoreDependencies.supportV4
 
     testImplementation aromaCoreTestDependencies.jUnit
     testImplementation aromaCoreTestDependencies.robolectric

--- a/aroma-core/build.gradle
+++ b/aroma-core/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     def aromaCoreDependencies = rootProject.ext.aromaCoreDependencies
     def aromaCoreTestDependencies = rootProject.ext.aromaCoreTestDependencies
 
-    implementation aromaCoreDependencies.supportAnnotations
+    implementation aromaCoreDependencies.androidxAnnotations
 
     testImplementation aromaCoreTestDependencies.jUnit
     testImplementation aromaCoreTestDependencies.robolectric

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.2.61'
+    ext.kotlin_version = '1.3.21'
 
     repositories {
         google()
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,27 +1,26 @@
 ext {
     // Android
-    androidBuildToolsVersion = "27.0.3"
+    androidBuildToolsVersion = "28.0.3"
     androidMinSdkVersion = 14
-    androidTargetSdkVersion = 27
-    androidCompileSdkVersion = 27
+    androidTargetSdkVersion = 28
+    androidCompileSdkVersion = 28
 
     // Kotlin
-    kotlinVersion = '1.2.61'
+    kotlinVersion = '1.3.21'
 
     // Libraries
-    androidSupportAnnotationsVerion = '27.1.1'
+    androidxAnnotationsVerion = '1.0.0'
     androidSupportVersion = '27.1.1'
     dexmakerVersion = '1.0'
 
     // Testing
     jUnitVersion = '4.12'
-    robolectricVersion = '4.0-alpha-3'
+    robolectricVersion = '4.2'
     mockitoCoreVersion = '2.17.0'
     dexmakerMockitoVersion = '1.0'
 
     aromaCoreDependencies = [
-            supportAnnotations:     "com.android.support:support-annotations:${androidSupportAnnotationsVerion}",
-            supportV4:              "com.android.support:support-annotations:${androidSupportVersion}"
+            supportAnnotations:     "androidx.annotation:annotation:${androidxAnnotationsVerion}"
     ]
 
     aromaCoreTestDependencies = [

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
     dexmakerMockitoVersion = '1.0'
 
     aromaCoreDependencies = [
-            supportAnnotations:     "androidx.annotation:annotation:${androidxAnnotationsVerion}"
+            androidxAnnotations:     "androidx.annotation:annotation:${androidxAnnotationsVerion}"
     ]
 
     aromaCoreTestDependencies = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
- Updated Kotlin version to 1.3.21
- Updated Gradle plugin version to 3.3.1
- Updated Android Build Tools version to 28.0.3
- Updated Android Target SDK and Android Compile SDK versions to 28
- Replaced Android Support Annotations to AndroidX Annotations
- Updated Robolectric version to 4.2